### PR TITLE
temporarily use pat before migrating to github app for authentication

### DIFF
--- a/.github/workflows/gitbook-action.yml
+++ b/.github/workflows/gitbook-action.yml
@@ -30,4 +30,4 @@ jobs:
           build_dir: _book
           fqdn: docs.ggxchain.io
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PAT: ${{ secrets.PERSONAL_TOKEN }}


### PR DESCRIPTION
looks like we were using PAT for authentication, it'll be changed with github app but this should fix authentication issue for now